### PR TITLE
PR運用ルールを AGENTS と Skill に整理

### DIFF
--- a/.codex/skills/pr-workflow/SKILL.md
+++ b/.codex/skills/pr-workflow/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: pr-workflow
+description: Create and edit GitHub pull requests with safe branch hygiene and markdown-safe PR descriptions. Use when Codex needs to create a PR, update a PR body or title, prepare PR body templates, or verify that PR markdown renders with real line breaks instead of escaped newline text.
+---
+
+# PR Workflow
+
+## Required Rules
+- Create a dedicated new branch for each pull request.
+- Never create a pull request from a reused branch.
+- Never pass escaped newline sequences like `\n` as PR body content.
+- Use real line breaks via a body file, then verify rendered markdown.
+
+## Create a Pull Request
+1. Create and switch to a new branch: `git checkout -b <topic-branch>`
+2. Write the PR body in a file with real line breaks.
+3. Create the PR with `gh pr create --title "<title>" --body-file <path-to-body-file>`
+4. Verify rendering with `gh pr view --web` or `gh pr view <number> --json body,url`
+
+## Edit an Existing Pull Request
+1. Update the same body file or create a new file with real line breaks.
+2. Run `gh pr edit <number> --title "<title>" --body-file <path-to-body-file>`
+3. Verify rendered markdown again.
+
+## Template
+- Use `references/pr-body-template.md` as the base.
+- Keep sections that are not used as `N/A` instead of deleting headers.

--- a/.codex/skills/pr-workflow/references/pr-body-template.md
+++ b/.codex/skills/pr-workflow/references/pr-body-template.md
@@ -1,0 +1,16 @@
+## Summary
+- 
+
+## Changes
+- 
+
+## Test
+- [ ] Not run (reason: )
+- [ ] Run: 
+
+## Risk and Rollback
+- Risk:
+- Rollback:
+
+## Notes
+- 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Agent Rules
+
+## Pull Request Rule
+- Always create a dedicated new branch before creating a pull request.
+- Do not create pull requests from a reused existing branch.
+- Create pull request titles and descriptions in Japanese by default.
+- Use the `pr-workflow` skill for PR description formatting and post-create checks.
+- Skill file: `c:/Projects/ws/flutter_recipe_app/.codex/skills/pr-workflow/SKILL.md`
+
+## Rule Update Meta Rule
+- Treat user instructions that indicate recurring behavior (for example: "always", "every time", "from now on", "rule") as persistent rule candidates.
+- For each persistent rule candidate, propose where to record it (`AGENTS.md` or a Skill) and provide a draft rule text.
+- Update files only after explicit user confirmation ("confirm before append" is the default behavior).
+- Before finishing a task, report in one line whether any new persistent rule candidate was detected.


### PR DESCRIPTION
## 概要
- PR運用ルールを `AGENTS.md` と `pr-workflow` Skill に整理し、再利用しやすい形にしました。
- 本PRは `main` 起点の新規ブランチから作成しており、差分はこの変更のみです。

## 変更内容
- `AGENTS.md` を追加し、PR運用ルールを定義。
- `AGENTS.md` に「PRタイトル/本文は日本語で作成する」ルールを追加。
- `AGENTS.md` に「恒久ルール候補は確認後に追記する」メタルールを追加。
- `.codex/skills/pr-workflow/SKILL.md` を追加。
- `.codex/skills/pr-workflow/references/pr-body-template.md` を追加。

## テスト
- [x] 未実施（理由: ドキュメント/運用ルール変更のみのため）

## リスクとロールバック
- リスク: 低。コード変更はなく、指示文書のみの変更です。
- ロールバック: `2adddae` を revert してください。

## 補足
- 既存PR #4 は履歴上の過去コミットが混在しているため、このPRをクリーン版として作成しています。