### PR TITLE
docs: AGENTS.md に履歴クリーン運用ルールを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,10 @@
 - For each persistent rule candidate, propose where to record it (`AGENTS.md` or a Skill) and provide a draft rule text.
 - Update files only after explicit user confirmation ("confirm before append" is the default behavior).
 - Before finishing a task, report in one line whether any new persistent rule candidate was detected.
+
+## Git History Hygiene (General)
+- Here, "work" means a single goal-oriented work unit (usually one PR branch), not a single commit.
+- Before starting a new goal-oriented work unit, run `git status -sb` and `git log --oneline origin/main..HEAD` to confirm history cleanliness.
+- If unrelated commits or diffs are present, create a new working branch from the latest `main`, then carry only required diffs (for example, by cherry-pick) before starting.
+- Multiple commits during the same work unit are allowed.
+- Before creating a PR (or requesting review), re-check that no unrelated diffs are mixed in.


### PR DESCRIPTION
## Summary
- AGENTS.md に履歴クリーン運用ルールを追加

## Changes
- `Git History Hygiene (General)` セクションを追加
- 作業単位の定義（1コミットではなく1目的・通常1PRブランチ）を明記
- 作業開始前/PR前のチェック手順を明記

## Test
- [x] Not run (reason: ドキュメント変更のみ)
- [ ] Run: N/A

## Risk and Rollback
- Risk: 低
- Rollback: このPRのコミットをrevertする

## Notes
- N/A