### PR TITLE
ci: PR時のtest/build重複実行を防止

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,34 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "lib/**"
+      - "test/**"
+      - "android/**"
+      - "ios/**"
+      - "web/**"
+      - "linux/**"
+      - "macos/**"
+      - "windows/**"
+      - "pubspec.yaml"
+      - "pubspec.lock"
+      - "analysis_options.yaml"
+      - ".fvmrc"
   push:
     branches: [main]
+    paths:
+      - "lib/**"
+      - "test/**"
+      - "android/**"
+      - "ios/**"
+      - "web/**"
+      - "linux/**"
+      - "macos/**"
+      - "windows/**"
+      - "pubspec.yaml"
+      - "pubspec.lock"
+      - "analysis_options.yaml"
+      - ".fvmrc"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- プルリクエスト更新時に `test` と `build` が二重実行される問題を抑制
- ドキュメント/運用ルール変更ではCIが実行されないよう、ソース関連変更のみに実行対象を限定

## Changes
- `pull_request` を `main` 向けに限定
- `pull_request` の `types` を `opened/synchronize/reopened/ready_for_review` に限定
- `push` を `main` のみに限定
- `pull_request` / `push` に `paths` を追加し、`lib/**` `test/**` `android/**` などのソース関連のみを対象化
- `concurrency.group` を `${{ github.head_ref || github.ref_name }}` ベースに変更

## Test
- [x] Not run (reason: GitHub Actions設定変更のみ)
- [ ] Run: N/A

## Risk and Rollback
- Risk: 中（`paths` 条件に含まれない変更ではCIが実行されない）
- Rollback: このPRのコミットをrevertし、従来トリガーに戻す

## Notes
- 仕様上、`README.md` `AGENTS.md` `docs/**` `.github/**` のみ変更ではCIは起動しない