### PR TITLE
docs: AGENTS軽量化と履歴衛生Skill追加

### DIFF
--- a/.codex/skills/git-history-hygiene/SKILL.md
+++ b/.codex/skills/git-history-hygiene/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: git-history-hygiene
+description: Keep git history clean for each goal-oriented work unit. Use when Codex starts new implementation work, prepares a PR/review request, or needs to ensure unrelated commits/diffs are not mixed.
+---
+
+# Git History Hygiene
+
+## Required Rules
+- Treat one "work" as one goal-oriented work unit (usually one PR branch), not one commit.
+- Before starting a new work unit, run `git status -sb` and `git log --oneline origin/main..HEAD`.
+- If unrelated commits or diffs are present, create a new branch from the latest `main` and carry only required diffs (for example: cherry-pick).
+- Multiple commits are allowed within the same work unit.
+- Before creating a PR or requesting review, check again that unrelated diffs are not mixed.
+
+## Start-Of-Work Checks
+1. Run `git status -sb`.
+2. Run `git log --oneline origin/main..HEAD`.
+3. If the worktree is clean and no unrelated commits are listed, continue.
+4. If unrelated changes exist, move work to a clean branch from `main`.
+
+## Pre-PR Checks
+1. Run `git status -sb`.
+2. Confirm only intended files are changed.
+3. Run `git log --oneline origin/main..HEAD`.
+4. Confirm only intended commits are included.

--- a/.codex/skills/pr-workflow/SKILL.md
+++ b/.codex/skills/pr-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-workflow
-description: Create and edit GitHub pull requests with safe branch hygiene and markdown-safe PR descriptions. Use when Codex needs to create a PR, update a PR body or title, prepare PR body templates, or verify that PR markdown renders with real line breaks instead of escaped newline text.
+description: Create and edit GitHub pull requests with safe branch hygiene, Japanese-by-default PR writing, and markdown-safe PR descriptions. Use when Codex needs to create a PR, update a PR body or title, prepare PR body templates, or verify that PR markdown renders with real line breaks instead of escaped newline text.
 ---
 
 # PR Workflow
@@ -8,6 +8,7 @@ description: Create and edit GitHub pull requests with safe branch hygiene and m
 ## Required Rules
 - Create a dedicated new branch for each pull request.
 - Never create a pull request from a reused branch.
+- Write pull request titles and descriptions in Japanese by default.
 - Never pass escaped newline sequences like `\n` as PR body content.
 - Use real line breaks via a body file, then verify rendered markdown.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,12 @@
 # Agent Rules
 
 ## Pull Request Rule
-- Always create a dedicated new branch before creating a pull request.
-- Do not create pull requests from a reused existing branch.
-- Create pull request titles and descriptions in Japanese by default.
-- Use the `pr-workflow` skill for PR description formatting and post-create checks.
+- Use the `pr-workflow` skill for branch hygiene, Japanese PR writing, PR description formatting, and post-create checks.
 - Skill file: `c:/Projects/ws/flutter_recipe_app/.codex/skills/pr-workflow/SKILL.md`
+
+## Git History Hygiene Rule
+- Use the `git-history-hygiene` skill before starting a new goal-oriented work unit and before creating a PR/review request.
+- Skill file: `c:/Projects/ws/flutter_recipe_app/.codex/skills/git-history-hygiene/SKILL.md`
 
 ## Rule Update Meta Rule
 - Treat user instructions that indicate recurring behavior (for example: "always", "every time", "from now on", "rule") as persistent rule candidates.


### PR DESCRIPTION
## 概要
- AGENTS.md を常時適用ルール中心に整理し、詳細手順を Skill へ移管
- Git 履歴衛生ルールを新規 Skill git-history-hygiene として追加
- pr-workflow Skill に「PR タイトル/本文は日本語デフォルト」を明記

## 変更内容
- AGENTS.md: PR 詳細ルールを削減し、Skill 参照中心に変更
- .codex/skills/pr-workflow/SKILL.md: 日本語デフォルト規約を追加
- .codex/skills/git-history-hygiene/SKILL.md: 新規作成

## テスト
- [x] 未実行（理由: ドキュメント変更のみ）

## リスクとロールバック
- リスク: 実行コードの変更はなく低リスク
- ロールバック: この PR のコミットを revert

## 補足
- なし