### PR TITLE
docs: PR本文一時ファイル運用ルールと.gitignoreを更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 
 # Flutter/Dart generated tool metadata
 .dart_tool/
+/build/
+/.flutter-plugins-dependencies
+
+# Temporary files for PR workflow
+/pr-body-*.md

--- a/agent-skills/pr-workflow/SKILL.md
+++ b/agent-skills/pr-workflow/SKILL.md
@@ -11,9 +11,11 @@ description: Create and edit GitHub pull requests with safe branch hygiene, Japa
 - Write pull request titles and descriptions in Japanese by default.
 - Never pass escaped newline sequences like `\n` as PR body content.
 - Always save PR body files as UTF-8 (without BOM). Do not rely on shell default encodings.
+- Name temporary PR body files as `pr-body-<topic>.md` in the repository root.
 - Use real line breaks via a body file, then verify rendered markdown.
 - After creating or editing a PR, verify `body` via `gh pr view <number> --json body,title,url`.
 - If mojibake is detected, rewrite the body file in UTF-8 (without BOM) and run `gh pr edit --body-file` immediately.
+- After creating or editing a PR, delete temporary PR body files matching `pr-body-*.md`.
 - For functional changes, confirm related docs are updated or include a clear reason in the PR body for why updates are unnecessary.
 
 ## Create a Pull Request
@@ -23,11 +25,13 @@ description: Create and edit GitHub pull requests with safe branch hygiene, Japa
    - Or a short reason if no documentation update was needed
 3. Create the PR with `gh pr create --title "<title>" --body-file <path-to-body-file>`
 4. Verify rendering and encoding with `gh pr view <number> --json body,title,url`
+5. Delete the temporary PR body file (`pr-body-*.md`).
 
 ## Edit an Existing Pull Request
 1. Update the same body file or create a new UTF-8 (without BOM) file with real line breaks.
 2. Run `gh pr edit <number> --title "<title>" --body-file <path-to-body-file>`
 3. Verify rendered markdown and encoding again with `gh pr view <number> --json body,title,url`.
+4. Delete the temporary PR body file (`pr-body-*.md`).
 
 ## PowerShell Encoding Tip
 - In PowerShell, prefer explicit UTF-8 (without BOM) writes:


### PR DESCRIPTION
## Summary
- PR本文一時ファイルの命名規則を `pr-body-<topic>.md` に明文化しました。
- PR作成/更新後に `pr-body-*.md` を削除する運用を `pr-workflow` に追加しました。
- 一時ファイル・生成ファイルの誤追跡防止のため `.gitignore` を更新しました。

## Changes
- `agent-skills/pr-workflow/SKILL.md`
  - Required Rules に命名規則と削除ルールを追加
  - Create/Edit 手順に本文ファイル削除ステップを追加
- `.gitignore`
  - `/build/`
  - `/.flutter-plugins-dependencies`
  - `/pr-body-*.md`

## Test
- [x] Not run (reason: ドキュメント/運用ルールと ignore 設定の変更のみ)
- [ ] Run: 

## Risk and Rollback
- Risk: 低。運用ルール追加と ignore 設定のみ。
- Rollback: 本PRをrevertすれば元に戻せます。

## Notes
- `docs/functional-requirements.md` / `docs/architecture.md` の更新は不要（アプリ機能変更なし）。